### PR TITLE
Adds say_mod variable to felinids

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -2,6 +2,7 @@
 /datum/species/human/felinid
 	name = "Felinid"
 	id = "felinid"
+	say_mod = "meows"
 	limbs_id = "human"
 
 	mutant_bodyparts = list("ears", "tail_human")

--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -2,7 +2,7 @@
 /datum/species/human/felinid
 	name = "Felinid"
 	id = "felinid"
-	say_mod = "meows"
+	say_mod = "yaps"
 	limbs_id = "human"
 
 	mutant_bodyparts = list("ears", "tail_human")

--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -2,7 +2,7 @@
 /datum/species/human/felinid
 	name = "Felinid"
 	id = "felinid"
-	say_mod = "yaps"
+	say_mod = "blithers"
 	limbs_id = "human"
 
 	mutant_bodyparts = list("ears", "tail_human")

--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -2,7 +2,7 @@
 /datum/species/human/felinid
 	name = "Felinid"
 	id = "felinid"
-	say_mod = "blithers"
+	say_mod = "meows"
 	limbs_id = "human"
 
 	mutant_bodyparts = list("ears", "tail_human")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Felinids now "meow" when they speak, in the same way that a lizard hisses or a plasmaman rattles.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It can be difficult for asimov silicons to distinguish felinids from normal humans, especially over the radio. This should help rectify that issue.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Felinid speech is now audibly distinct from human speech.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
